### PR TITLE
[tests-only] Bump phan analysis to v4.0

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -25,7 +25,7 @@ use Phan\Issue;
 
 return [
 
-	// Supported values: '7.0', '7.1', '7.2', null.
+	// Supported values: '7.2', '7.3', '7.4', '8.0', null.
 	// If this is set to null,
 	// then Phan assumes the PHP version which is closest to the minor version
 	// of the php executable used to execute phan.

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^3.2"
+        "phan/phan": "^4.0"
     }
 }


### PR DESCRIPTION
https://github.com/phan/phan/releases/tag/4.0.0

A new major version of phan was released a while ago. It supports PHP 7.2, 7.3, 7.4 and 8.0. Use it.
