### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+## [0.7.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [0.7.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [0.6.0] - 2019-11-28
 
 ## Fixed
@@ -22,6 +33,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Set max version to 10
 
-[Unreleased]: https://github.com/owncloud/user_external/compare/v0.6.0...master
+[Unreleased]: https://github.com/owncloud/user_external/compare/v0.7.1..master
+[0.7.1]: https://github.com/owncloud/user_external/compare/v0.7.0..v0.7.1
+[0.7.0]: https://github.com/owncloud/user_external/compare/v0.6.0..v0.7.0
 [0.6.0]: https://github.com/owncloud/user_external/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/owncloud/user_external/compare/v0.4.1...v0.5.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 		<owncloud min-version="11" max-version="11" />
 		<php min-version="8.3" />
 	</dependencies>
-	<version>0.7.0</version>
+	<version>0.7.1</version>
 	<types>
 		<authentication/>
 		<prelogin/>


### PR DESCRIPTION
Patch-level version bump (0.7.0 -> 0.7.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.